### PR TITLE
feat(contest) : 러닝 대회 목록, 러닝 대회 상세 조회 API 연동

### DIFF
--- a/src/app/(pages)/contest/[id]/_components/contest-details.tsx
+++ b/src/app/(pages)/contest/[id]/_components/contest-details.tsx
@@ -1,9 +1,9 @@
 interface ContestDetailsProps {
-  period: string;
+  period?: string;
   organizer: string;
   fees: Array<{
     distance: string;
-    price: number;
+    price: string;
     label: string;
   }>;
 }
@@ -11,10 +11,12 @@ interface ContestDetailsProps {
 export function ContestDetails({ period, organizer, fees }: ContestDetailsProps) {
   return (
     <div className='flex flex-col gap-2 px-6'>
-      <div className='flex'>
-        <span className='text-body3 text-gray-4 w-16'>접수기간</span>
-        <span className='text-body4 text-black'>{period}</span>
-      </div>
+      {period && (
+        <div className='flex'>
+          <span className='text-body3 text-gray-4 w-16'>접수기간</span>
+          <span className='text-body4 text-black'>{period}</span>
+        </div>
+      )}
 
       <div className='flex'>
         <span className='text-body3 text-gray-4 w-16'>주최사</span>
@@ -26,7 +28,7 @@ export function ContestDetails({ period, organizer, fees }: ContestDetailsProps)
         <div className='flex flex-col gap-1'>
           {fees.map((fee, index) => (
             <div key={index} className='flex items-center gap-1'>
-              <span className='text-body3 text-black'>{fee.price.toLocaleString()}원</span>
+              <span className='text-body3 text-black'>{fee.price}</span>
               <span className='text-body4 text-black'>{fee.label}</span>
             </div>
           ))}

--- a/src/app/(pages)/contest/[id]/page.tsx
+++ b/src/app/(pages)/contest/[id]/page.tsx
@@ -1,56 +1,71 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { useEffect, useState, use } from 'react';
 import { PageHeader } from '@/components/page-header';
 import { cn } from '@/utils/cn';
 import { ContestInfo } from './_components/contest-info';
 import { ContestDetails } from './_components/contest-details';
 import { RecommendedCourses } from './_components/recommended-courses';
-
-const CONTEST_DETAIL = {
-  id: '1',
-  date: '09. 07.',
-  day: '토요일',
-  title: 'RUN SEOUL RUN',
-  location: '서울, 시청 광장',
-  distances: ['5km', '10km'],
-  period: '2025. 09. 01 - 2025. 09. 07',
-  organizer: '이데일리M',
-  fees: [
-    { distance: '5km', price: 79000, label: '(하프)' },
-    { distance: '10km', price: 59000, label: '(10km)' },
-  ],
-};
-
-const RECOMMENDED_COURSES = [
-  {
-    id: '1',
-    title: '망양강 자전거길',
-    location: '경남 말양시',
-    imageUrl: '/img/home/home.png',
-  },
-  {
-    id: '2',
-    title: '망양강 자전거길',
-    location: '경남 말양시',
-    imageUrl: '/img/home/home.png',
-  },
-  {
-    id: '3',
-    title: '망양강 자전거길',
-    location: '경남 말양시',
-    imageUrl: '/img/home/home.png',
-  },
-];
+import { getMarathonDetail } from '@/lib/api/contest';
+import { MarathonDetail } from '@/interfaces/contest/contest.types';
 
 interface ContestDetailPageProps {
-  params: {
+  params: Promise<{
     id: string;
-  };
+  }>;
 }
 
 export default function ContestDetailPage({ params }: ContestDetailPageProps) {
   const router = useRouter();
+  const resolvedParams = use(params);
+  const [contestData, setContestData] = useState<MarathonDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchContestDetail = async () => {
+      try {
+        const response = await getMarathonDetail(resolvedParams.id);
+        setContestData(response.data);
+      } catch (error) {
+        console.error('Failed to fetch contest detail:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchContestDetail();
+  }, [resolvedParams.id]);
+
+  if (loading) {
+    return (
+      <div className='flex h-screen flex-col bg-gray-50'>
+        <PageHeader
+          title='러닝 대회'
+          isLeftIcon
+          onClickLeftIcon={() => router.back()}
+        />
+        <div className='flex flex-1 items-center justify-center'>
+          <div>로딩 중...</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!contestData) {
+    return (
+      <div className='flex h-screen flex-col bg-gray-50'>
+        <PageHeader
+          title='러닝 대회'
+          isLeftIcon
+          onClickLeftIcon={() => router.back()}
+        />
+        <div className='flex flex-1 items-center justify-center'>
+          <div>대회 정보를 찾을 수 없습니다.</div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className='flex h-screen flex-col bg-gray-50'>
@@ -64,30 +79,43 @@ export default function ContestDetailPage({ params }: ContestDetailPageProps) {
 
       <div className='flex-1 overflow-y-auto'>
         <ContestInfo
-          date={CONTEST_DETAIL.date}
-          day={CONTEST_DETAIL.day}
-          title={CONTEST_DETAIL.title}
-          location={CONTEST_DETAIL.location}
-          distances={CONTEST_DETAIL.distances}
+          date={`${contestData.month}. ${contestData.day}.`}
+          day={contestData.dayOfWeek}
+          title={contestData.title}
+          location={contestData.addr}
+          distances={contestData.prices.map(price => price.type)}
         />
 
         <ContestDetails
-          period={CONTEST_DETAIL.period}
-          organizer={CONTEST_DETAIL.organizer}
-          fees={CONTEST_DETAIL.fees}
+          organizer={contestData.host}
+          fees={contestData.prices.map(price => ({
+            distance: price.type,
+            price: price.price,
+            label: `(${price.type})`,
+          }))}
         />
 
         <div className='h-9' />
 
-        <RecommendedCourses courses={RECOMMENDED_COURSES} />
+        <RecommendedCourses
+          courses={contestData.courseInfos.map(course => ({
+            id: course.crsIdx,
+            title: course.crsKorNm,
+            location: course.sigun,
+            imageUrl: course.crsImgUrl,
+          }))}
+        />
 
         <div className='h-12' />
         <div
           className={cn('px-5 pt-5', {
-            'border-gray-1 border-t': RECOMMENDED_COURSES.length > 0,
+            'border-gray-1 border-t': contestData.courseInfos.length > 0,
           })}
         >
-          <button className='text-title2 bg-point-400 w-full rounded-[12px] py-3 text-white'>
+          <button
+            className='text-title2 bg-point-400 w-full rounded-[12px] py-3 text-white'
+            onClick={() => window.open(contestData.homepageUrl, '_blank')}
+          >
             홈페이지로 이동하기
           </button>
         </div>

--- a/src/app/(pages)/contest/_components/contest-card.tsx
+++ b/src/app/(pages)/contest/_components/contest-card.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/utils/cn';
+import { sortDistances } from '../_utils/sort-distances';
 import { DistanceBadge } from './distance-badge';
 import { ContestDate } from './contest-date';
 import { ContestLocation } from './contest-location';
@@ -42,7 +43,7 @@ export function ContestCard({
           <ContestLocation location={location} />
 
           <div className='mt-2 flex gap-2'>
-            {distances.map((distance, index) => (
+            {sortDistances(distances).map((distance, index) => (
               <DistanceBadge key={index} distance={distance} />
             ))}
           </div>

--- a/src/app/(pages)/contest/_components/contest-date.tsx
+++ b/src/app/(pages)/contest/_components/contest-date.tsx
@@ -13,9 +13,9 @@ export function ContestDate({ date, day, className }: ContestDateProps) {
       <span
         className={clsx(
           'text-title3',
-          day === '토요일'
+          day === '토'
             ? 'text-weather-bl-02'
-            : day === '일요일'
+            : day === '일'
               ? 'text-weather-or-02'
               : 'text-gray-4',
         )}

--- a/src/app/(pages)/contest/_components/contest-skeleton.tsx
+++ b/src/app/(pages)/contest/_components/contest-skeleton.tsx
@@ -1,0 +1,12 @@
+export function ContestSkeleton() {
+  return (
+    <div className='flex flex-col gap-7 overflow-y-auto px-4 py-5'>
+      {Array.from({ length: 6 }).map((_, index) => (
+        <div
+          key={index}
+          className='h-32 animate-pulse rounded-lg bg-gray-200'
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/app/(pages)/contest/_utils/sort-distances.ts
+++ b/src/app/(pages)/contest/_utils/sort-distances.ts
@@ -1,0 +1,9 @@
+export function sortDistances(distances: string[]): string[] {
+  return distances.sort((a, b) => {
+    const parseDistance = (d: string) => {
+      const num = parseFloat(d.replace(/[^0-9.]/g, ''));
+      return isNaN(num) ? 0 : num;
+    };
+    return parseDistance(a) - parseDistance(b);
+  });
+}

--- a/src/app/(pages)/contest/page.tsx
+++ b/src/app/(pages)/contest/page.tsx
@@ -1,46 +1,19 @@
 'use client';
+
+import { useQuery } from '@tanstack/react-query';
 import { ContestCard } from './_components/contest-card';
 import { PageHeader } from '@/components/page-header';
 import { useRouter } from 'next/navigation';
-
-const CONTEST_DATA = [
-  {
-    id: '1',
-    date: '09. 07.',
-    day: '토요일',
-    title: 'RUN SEOUL RUN',
-    location: '서울, 시청 광장',
-    distances: ['5km', '10km'],
-    isUpcoming: true,
-  },
-  {
-    id: '2',
-    date: '09. 08.',
-    day: '일요일',
-    title: 'RUN SEOUL RUN',
-    location: '서울, 시청 광장',
-    distances: ['5km', '10km'],
-  },
-  {
-    id: '3',
-    date: '09. 07.',
-    day: '월요일',
-    title: 'RUN SEOUL RUN',
-    location: '서울, 시청 광장',
-    distances: ['5km', '10km'],
-  },
-  {
-    id: '4',
-    date: '09. 07.',
-    day: '토요일',
-    title: 'RUN SEOUL RUN',
-    location: '서울, 시청 광장',
-    distances: ['5km', '10km'],
-  },
-];
+import { getMarathons } from '@/lib/api/contest';
+import { ContestSkeleton } from './_components/contest-skeleton';
 
 export default function ContestPage() {
   const router = useRouter();
+
+  const { data: marathonData, isLoading } = useQuery({
+    queryKey: ['marathons', 1],
+    queryFn: () => getMarathons(1),
+  });
 
   const handleContestClick = (id: string) => {
     router.push(`/contest/${id}`);
@@ -53,22 +26,29 @@ export default function ContestPage() {
       <nav className='bg-gray-0 h-2 w-full' />
 
       {/* 대회 목록 */}
-      <div className='flex flex-col gap-7 overflow-y-auto px-4 py-5'>
-        {CONTEST_DATA.map(contest => (
-          <ContestCard
-            key={contest.id}
-            id={contest.id}
-            date={contest.date}
-            day={contest.day}
-            title={contest.title}
-            location={contest.location}
-            distances={contest.distances}
-            onClick={handleContestClick}
-          />
-        ))}
-      </div>
+      {isLoading ? (
+        <ContestSkeleton />
+      ) : (
+        <div className='flex flex-col gap-7 overflow-y-auto px-4 py-5'>
+          {marathonData?.data?.content?.map(item => {
+            const marathon = item.data;
+            return (
+              <ContestCard
+                key={marathon.marathonId}
+                id={marathon.marathonId.toString()}
+                date={`${marathon.month}. ${marathon.day}.`}
+                day={marathon.dayOfWeek}
+                title={marathon.title}
+                location={marathon.addr}
+                distances={marathon.types}
+                onClick={handleContestClick}
+              />
+            );
+          })}
+        </div>
+      )}
 
-      <div className='h-25' />
+      <div className='h-50' />
     </div>
   );
 }

--- a/src/interfaces/contest/contest.types.ts
+++ b/src/interfaces/contest/contest.types.ts
@@ -1,0 +1,69 @@
+export interface Marathon {
+  marathonId: number;
+  title: string;
+  addr: string;
+  month: string;
+  day: string;
+  dayOfWeek: string;
+  types: string[];
+  applying: boolean;
+}
+
+export interface MarathonDetailPrice {
+  type: string;
+  price: string;
+}
+
+export interface MarathonDetailCourseInfo {
+  crsIdx: string;
+  crsKorNm: string;
+  sigun: string;
+  crsImgUrl: string;
+}
+
+export interface MarathonDetail {
+  marathonId: number;
+  title: string;
+  month: string;
+  day: string;
+  dayOfWeek: string;
+  addr: string;
+  host: string;
+  prices: MarathonDetailPrice[];
+  courseInfos: MarathonDetailCourseInfo[];
+  homepageUrl: string;
+}
+
+export interface MarathonContent {
+  data: Marathon;
+  pageInfo: any;
+}
+
+export interface MarathonSort {
+  empty: boolean;
+  sorted: boolean;
+  unsorted: boolean;
+}
+
+export interface MarathonPageable {
+  pageNumber: number;
+  pageSize: number;
+  sort: MarathonSort;
+  offset: number;
+  paged: boolean;
+  unpaged: boolean;
+}
+
+export interface MarathonResponse {
+  content: MarathonContent[];
+  pageable: MarathonPageable;
+  totalElements: number;
+  totalPages: number;
+  last: boolean;
+  size: number;
+  number: number;
+  sort: MarathonSort;
+  numberOfElements: number;
+  first: boolean;
+  empty: boolean;
+}

--- a/src/lib/api/contest/index.ts
+++ b/src/lib/api/contest/index.ts
@@ -1,0 +1,21 @@
+import { ApiResponse } from '@/interfaces/api/response.types';
+import { MarathonResponse, MarathonDetail } from '@/interfaces/contest/contest.types';
+import { api } from '@/lib/api';
+
+/**
+ * 대회 정보 가져오는 API
+ */
+export const getMarathons = async (
+  page: number = 1,
+): Promise<ApiResponse<MarathonResponse>> => {
+  return await api.get(`/public/marathons?page=${page}`);
+};
+
+/**
+ * 대회 상세 정보 가져오는 API
+ */
+export const getMarathonDetail = async (
+  marathonId: string,
+): Promise<ApiResponse<MarathonDetail>> => {
+  return await api.get(`/public/marathons/${marathonId}`);
+};


### PR DESCRIPTION
### Issue Number

close: #

### 작업 내역

> 러닝 대회 목록, 러닝 대회 상세조회 API 연동


### 변경사항

<img width="375" height="670" alt="image" src="https://github.com/user-attachments/assets/5623e431-f7f0-465f-a973-1732cd1ff265" />
<img width="372" height="663" alt="image" src="https://github.com/user-attachments/assets/613b3629-59c6-4258-9a49-adfc23927b1d" />


### PR 특이 사항

> 러닝 대회 목록에서 km단위로 보여줄 때 프론트에서 정렬해뒀습니다. 상세 조회에서는 정렬해서 반환하도록 백엔드에 요청했습니다.

### Checklist

> PR 등록 전 확인할 점

- [ ] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가 (e.g.,
      `feat(user): add login page`)
- [ ] assignee가 본인으로 되어있고, label은 PR 주제에 맞게 추가했는가
- [ ] description에 PR에 대해 구체적으로 설명했는가
